### PR TITLE
Mappers

### DIFF
--- a/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/KeyMapper.java
+++ b/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/KeyMapper.java
@@ -1,10 +1,8 @@
 package com.mobilejazz.cacheio.alternative.mappers;
 
-
 public interface KeyMapper<T> {
 
-    String toString(T key);
+  String toString(T key);
 
-    T fromString(String str);
-
+  T fromString(String str);
 }

--- a/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/ValueMapper.java
+++ b/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/ValueMapper.java
@@ -2,13 +2,11 @@ package com.mobilejazz.cacheio.alternative.mappers;
 
 import com.mobilejazz.cacheio.exceptions.SerializerException;
 
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 
 public interface ValueMapper {
 
-    void write(Object value, OutputStream out) throws SerializerException;
+  void write(Object value, OutputStream out) throws SerializerException;
 
-    <T> T read(Class<T> type, InputStream in) throws SerializerException;
-
+  <T> T read(Class<T> type, InputStream in) throws SerializerException;
 }

--- a/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/VersionMapper.java
+++ b/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/VersionMapper.java
@@ -1,8 +1,6 @@
 package com.mobilejazz.cacheio.alternative.mappers;
 
-
 public interface VersionMapper<T> {
 
-    long getVersion(T model);
-
+  long getVersion(T model);
 }

--- a/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/DoubleKeyMapper.java
+++ b/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/DoubleKeyMapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 Mobile Jazz
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.mobilejazz.cacheio.alternative.mappers.defaults;
+
+import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
+
+import static com.mobilejazz.cacheio.internal.helper.Preconditions.checkArgument;
+
+public class DoubleKeyMapper implements KeyMapper<Double> {
+
+  @Override public String toString(Double key) {
+    checkArgument(key, "key cannot be null");
+    return key.toString();
+  }
+
+  @Override public Double fromString(String str) {
+    checkArgument(str, "str cannot be null");
+    return Double.parseDouble(str);
+  }
+}

--- a/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/FloatKeyMapper.java
+++ b/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/FloatKeyMapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 Mobile Jazz
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.mobilejazz.cacheio.alternative.mappers.defaults;
+
+import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
+
+import static com.mobilejazz.cacheio.internal.helper.Preconditions.checkArgument;
+
+public class FloatKeyMapper implements KeyMapper<Float> {
+
+  @Override public String toString(Float key) {
+    checkArgument(key, "key cannot be null");
+    return key.toString();
+  }
+
+  @Override public Float fromString(String str) {
+    checkArgument(str, "str cannot be null");
+    return Float.parseFloat(str);
+  }
+}

--- a/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/IntegerKeyMapper.java
+++ b/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/IntegerKeyMapper.java
@@ -7,11 +7,13 @@ import static com.mobilejazz.cacheio.internal.helper.Preconditions.checkArgument
 public class IntegerKeyMapper implements KeyMapper<Integer> {
 
   @Override public String toString(Integer key) {
-    return checkArgument(key, "key cannot be null").toString();
+    checkArgument(key, "key cannot be null");
+    return key.toString();
   }
 
   @Override public Integer fromString(String str) {
-    return Integer.parseInt(checkArgument(str, "str cannot be null"));
+    checkArgument(str, "str cannot be null");
+    return Integer.parseInt(str);
   }
 
 }

--- a/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/IntegerKeyMapper.java
+++ b/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/IntegerKeyMapper.java
@@ -1,20 +1,17 @@
 package com.mobilejazz.cacheio.alternative.mappers.defaults;
 
-
 import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
 
 import static com.mobilejazz.cacheio.internal.helper.Preconditions.checkArgument;
 
 public class IntegerKeyMapper implements KeyMapper<Integer> {
 
-    @Override
-    public String toString(Integer key) {
-        return checkArgument(key, "key cannot be null").toString();
-    }
+  @Override public String toString(Integer key) {
+    return checkArgument(key, "key cannot be null").toString();
+  }
 
-    @Override
-    public Integer fromString(String str) {
-        return Integer.parseInt(checkArgument(str, "str cannot be null"));
-    }
-    
+  @Override public Integer fromString(String str) {
+    return Integer.parseInt(checkArgument(str, "str cannot be null"));
+  }
+
 }

--- a/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/LongKeyMapper.java
+++ b/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/LongKeyMapper.java
@@ -7,11 +7,13 @@ import static com.mobilejazz.cacheio.internal.helper.Preconditions.checkArgument
 public class LongKeyMapper implements KeyMapper<Long> {
 
   @Override public String toString(Long key) {
-    return checkArgument(key, "key cannot be null").toString();
+    checkArgument(key, "key cannot be null");
+    return key.toString();
   }
 
   @Override public Long fromString(String str) {
-    return Long.parseLong(checkArgument(str, "str cannot be null"));
+    checkArgument(str, "str cannot be null");
+    return Long.parseLong(str);
   }
 
 }

--- a/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/LongKeyMapper.java
+++ b/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/LongKeyMapper.java
@@ -6,14 +6,12 @@ import static com.mobilejazz.cacheio.internal.helper.Preconditions.checkArgument
 
 public class LongKeyMapper implements KeyMapper<Long> {
 
-    @Override
-    public String toString(Long key) {
-        return checkArgument(key, "key cannot be null").toString();
-    }
+  @Override public String toString(Long key) {
+    return checkArgument(key, "key cannot be null").toString();
+  }
 
-    @Override
-    public Long fromString(String str) {
-        return Long.parseLong(checkArgument(str, "str cannot be null"));
-    }
-    
+  @Override public Long fromString(String str) {
+    return Long.parseLong(checkArgument(str, "str cannot be null"));
+  }
+
 }

--- a/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/ShortKeyMapper.java
+++ b/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/ShortKeyMapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 Mobile Jazz
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.mobilejazz.cacheio.alternative.mappers.defaults;
+
+import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
+
+import static com.mobilejazz.cacheio.internal.helper.Preconditions.checkArgument;
+
+public class ShortKeyMapper implements KeyMapper<Short> {
+
+  @Override public String toString(Short key) {
+    checkArgument(key, "key cannot be null");
+    return key.toString();
+  }
+
+  @Override public Short fromString(String str) {
+    checkArgument(str, "str cannot be null");
+    return Short.valueOf(str);
+  }
+}

--- a/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/StringKeyMapper.java
+++ b/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/StringKeyMapper.java
@@ -6,14 +6,12 @@ import static com.mobilejazz.cacheio.internal.helper.Preconditions.checkArgument
 
 public class StringKeyMapper implements KeyMapper<String> {
 
-    @Override
-    public String toString(String key) {
-        return checkArgument(key, "key cannot be null");
-    }
+  @Override public String toString(String key) {
+    return checkArgument(key, "key cannot be null");
+  }
 
-    @Override
-    public String fromString(String str) {
-        return checkArgument(str, "str cannot be null");
-    }
+  @Override public String fromString(String str) {
+    return checkArgument(str, "str cannot be null");
+  }
 
 }

--- a/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/StringKeyMapper.java
+++ b/cacheio-core/src/main/java/com/mobilejazz/cacheio/alternative/mappers/defaults/StringKeyMapper.java
@@ -7,11 +7,13 @@ import static com.mobilejazz.cacheio.internal.helper.Preconditions.checkArgument
 public class StringKeyMapper implements KeyMapper<String> {
 
   @Override public String toString(String key) {
-    return checkArgument(key, "key cannot be null");
+    checkArgument(key, "key cannot be null");
+    return key;
   }
 
   @Override public String fromString(String str) {
-    return checkArgument(str, "str cannot be null");
+    checkArgument(str, "str cannot be null");
+    return str;
   }
 
 }

--- a/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/DoubleKeyMapperTest.java
+++ b/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/DoubleKeyMapperTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016 Mobile Jazz
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.mobilejazz.cacheio.alternative.mappers.defaults;
+
+import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DoubleKeyMapperTest {
+
+  private final KeyMapper<Double> mapper = new DoubleKeyMapper();
+
+  @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void shouldThrowIllegalArgumentExceptionIfMappingToStringTheValueIsNull() {
+    mapper.toString(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringTheValueIsNull() {
+    mapper.fromString(null);
+  }
+
+  @Test public void shouldMappingToStringAValue() throws Exception {
+    String result = mapper.toString(1.2);
+
+    assertThat(result).isEqualTo("1.2");
+  }
+
+  @Test public void shouldMappingFromStringAValue() throws Exception {
+    Double result = mapper.fromString("1.2");
+
+    assertThat(result).isEqualTo(1.2);
+  }
+}

--- a/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/DoubleKeyMapperTest.java
+++ b/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/DoubleKeyMapperTest.java
@@ -26,12 +26,12 @@ public class DoubleKeyMapperTest {
   private final KeyMapper<Double> mapper = new DoubleKeyMapper();
 
   @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void shouldThrowIllegalArgumentExceptionIfMappingToStringTheValueIsNull() {
+  public void shouldThrowIllegalArgumentExceptionIfMappingToStringWithNullValue() {
     mapper.toString(null);
   }
 
   @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringTheValueIsNull() {
+  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringWithNullValue() {
     mapper.fromString(null);
   }
 

--- a/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/FloatKeyMapperTest.java
+++ b/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/FloatKeyMapperTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016 Mobile Jazz
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.mobilejazz.cacheio.alternative.mappers.defaults;
+
+import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FloatKeyMapperTest {
+
+  private final KeyMapper<Float> mapper = new FloatKeyMapper();
+
+  @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void shouldThrowIllegalArgumentExceptionIfMappingToStringTheValueIsNull() {
+    mapper.toString(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringTheValueIsNull() {
+    mapper.fromString(null);
+  }
+
+  @Test public void shouldMappingToStringAValue() throws Exception {
+    String result = mapper.toString(1f);
+
+    assertThat(result).isEqualTo("1.0");
+  }
+
+  @Test public void shouldMappingFromStringAValue() throws Exception {
+    Float result = mapper.fromString("1.0");
+
+    assertThat(result).isEqualTo(1f);
+  }
+}

--- a/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/FloatKeyMapperTest.java
+++ b/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/FloatKeyMapperTest.java
@@ -26,12 +26,12 @@ public class FloatKeyMapperTest {
   private final KeyMapper<Float> mapper = new FloatKeyMapper();
 
   @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void shouldThrowIllegalArgumentExceptionIfMappingToStringTheValueIsNull() {
+  public void shouldThrowIllegalArgumentExceptionIfMappingToStringWithNullValue() {
     mapper.toString(null);
   }
 
   @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringTheValueIsNull() {
+  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringWithNullValue() {
     mapper.fromString(null);
   }
 

--- a/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/IntegerKeyMapperTest.java
+++ b/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/IntegerKeyMapperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 Mobile Jazz
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package com.mobilejazz.cacheio.alternative.mappers.defaults;
 
 import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
@@ -10,12 +26,12 @@ public class IntegerKeyMapperTest {
   private final KeyMapper<Integer> mapper = new IntegerKeyMapper();
 
   @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void shouldThrowIllegalArgumentExceptionIfMappingToStringTheValueIsNull() {
+  public void shouldThrowIllegalArgumentExceptionIfMappingToStringWithNullValue() {
     mapper.toString(null);
   }
 
   @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringTheValueIsNull() {
+  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringWithNullValue() {
     mapper.fromString(null);
   }
 

--- a/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/IntegerKeyMapperTest.java
+++ b/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/IntegerKeyMapperTest.java
@@ -1,44 +1,33 @@
 package com.mobilejazz.cacheio.alternative.mappers.defaults;
 
+import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class IntegerKeyMapperTest {
 
-    private final IntegerKeyMapper mapper = new IntegerKeyMapper();
+  private final KeyMapper<Integer> mapper = new IntegerKeyMapper();
 
-    @Test(expected = IllegalArgumentException.class)
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    public void testToStringWithNullInteger(){
-        mapper.toString(null);
-    }
+  @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void shouldThrowIllegalArgumentExceptionIfMappingToStringTheValueIsNull() {
+    mapper.toString(null);
+  }
 
-    @Test(expected = IllegalArgumentException.class)
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    public void testFromStringWithNullString(){
-        mapper.fromString(null);
-    }
+  @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringTheValueIsNull() {
+    mapper.fromString(null);
+  }
 
-    @Test
-    public void testMappingToString(){
+  @Test public void shouldMappingToStringAValue() throws Exception {
+    String result = mapper.toString(1);
 
-        assertThat(mapper.toString(1)).isEqualTo("1");
-        assertThat(mapper.toString(2)).isEqualTo("2");
-        assertThat(mapper.toString(3)).isEqualTo("3");
-        assertThat(mapper.toString(4)).isEqualTo("4");
+    assertThat(result).isEqualTo("1");
+  }
 
-        assertThat(mapper.toString(1)).isNotEqualTo("4");
-    }
+  @Test public void shouldMappingFromStringAValue() throws Exception {
+    Integer result = mapper.fromString("1");
 
-    @Test
-    public void testMappingFromString(){
-
-        assertThat(mapper.fromString("1")).isEqualTo(1);
-        assertThat(mapper.fromString("2")).isEqualTo(2);
-        assertThat(mapper.fromString("3")).isEqualTo(3);
-        assertThat(mapper.fromString("4")).isEqualTo(4);
-
-        assertThat(mapper.fromString("1")).isNotEqualTo(4);
-    }
+    assertThat(result).isEqualTo(1);
+  }
 }

--- a/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/LongKeyMapperTest.java
+++ b/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/LongKeyMapperTest.java
@@ -1,44 +1,33 @@
 package com.mobilejazz.cacheio.alternative.mappers.defaults;
 
+import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LongKeyMapperTest {
 
-    private final LongKeyMapper mapper = new LongKeyMapper();
+  private final KeyMapper<Long> mapper = new LongKeyMapper();
 
-    @Test(expected = IllegalArgumentException.class)
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    public void testToStringWithNullInteger(){
-        mapper.toString(null);
-    }
+  @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void shouldThrowIllegalArgumentExceptionIfMappingToStringTheValueIsNull() {
+    mapper.toString(null);
+  }
 
-    @Test(expected = IllegalArgumentException.class)
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    public void testFromStringWithNullString(){
-        mapper.fromString(null);
-    }
+  @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringTheValueIsNull() {
+    mapper.fromString(null);
+  }
 
-    @Test
-    public void testMappingToString(){
+  @Test public void shouldMappingToStringAValue() throws Exception {
+    String result = mapper.toString(1L);
 
-        assertThat(mapper.toString(1L)).isEqualTo("1");
-        assertThat(mapper.toString(2L)).isEqualTo("2");
-        assertThat(mapper.toString(3L)).isEqualTo("3");
-        assertThat(mapper.toString(4L)).isEqualTo("4");
+    assertThat(result).isEqualTo("1");
+  }
 
-        assertThat(mapper.toString(1L)).isNotEqualTo("4");
-    }
+  @Test public void shouldMappingFromStringAValue() throws Exception {
+    Long result = mapper.fromString("1");
 
-    @Test
-    public void testMappingFromString(){
-
-        assertThat(mapper.fromString("1")).isEqualTo(1L);
-        assertThat(mapper.fromString("2")).isEqualTo(2L);
-        assertThat(mapper.fromString("3")).isEqualTo(3L);
-        assertThat(mapper.fromString("4")).isEqualTo(4L);
-
-        assertThat(mapper.fromString("1")).isNotEqualTo(4L);
-    }
+    assertThat(result).isEqualTo(1L);
+  }
 }

--- a/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/LongKeyMapperTest.java
+++ b/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/LongKeyMapperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 Mobile Jazz
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package com.mobilejazz.cacheio.alternative.mappers.defaults;
 
 import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
@@ -10,12 +26,12 @@ public class LongKeyMapperTest {
   private final KeyMapper<Long> mapper = new LongKeyMapper();
 
   @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void shouldThrowIllegalArgumentExceptionIfMappingToStringTheValueIsNull() {
+  public void shouldThrowIllegalArgumentExceptionIfMappingToStringWithNullValue() {
     mapper.toString(null);
   }
 
   @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringTheValueIsNull() {
+  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringWithNullValue() {
     mapper.fromString(null);
   }
 

--- a/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/ShortKeyMapperTest.java
+++ b/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/ShortKeyMapperTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016 Mobile Jazz
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.mobilejazz.cacheio.alternative.mappers.defaults;
+
+import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ShortKeyMapperTest {
+
+  private final KeyMapper<Short> mapper = new ShortKeyMapper();
+
+  @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void shouldThrowIllegalArgumentExceptionIfMappingToStringTheValueIsNull() {
+    mapper.toString(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringTheValueIsNull() {
+    mapper.fromString(null);
+  }
+
+  @Test public void shouldMappingToStringAValue() throws Exception {
+    String result = mapper.toString((short) 1);
+
+    assertThat(result).isEqualTo("1");
+  }
+
+  @Test public void shouldMappingFromStringAValue() throws Exception {
+    Short result = mapper.fromString(String.valueOf(Short.MIN_VALUE));
+
+    assertThat(result).isEqualTo(Short.MIN_VALUE);
+  }
+}

--- a/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/ShortKeyMapperTest.java
+++ b/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/ShortKeyMapperTest.java
@@ -26,12 +26,12 @@ public class ShortKeyMapperTest {
   private final KeyMapper<Short> mapper = new ShortKeyMapper();
 
   @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void shouldThrowIllegalArgumentExceptionIfMappingToStringTheValueIsNull() {
+  public void shouldThrowIllegalArgumentExceptionIfMappingToStringWithNullValue() {
     mapper.toString(null);
   }
 
   @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringTheValueIsNull() {
+  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringWithNullValue() {
     mapper.fromString(null);
   }
 

--- a/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/StringKeyMapperTest.java
+++ b/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/StringKeyMapperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 Mobile Jazz
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package com.mobilejazz.cacheio.alternative.mappers.defaults;
 
 import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
@@ -10,12 +26,12 @@ public class StringKeyMapperTest {
   private final KeyMapper<String> mapper = new StringKeyMapper();
 
   @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void shouldThrowIllegalArgumentExceptionIfMappingToStringTheValueIsNull() {
+  public void shouldThrowIllegalArgumentExceptionIfMappingToStringWithNullValue() {
     mapper.toString(null);
   }
 
   @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringTheValueIsNull() {
+  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringWithNullValue() {
     mapper.fromString(null);
   }
 

--- a/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/StringKeyMapperTest.java
+++ b/cacheio-core/src/test/java/com/mobilejazz/cacheio/alternative/mappers/defaults/StringKeyMapperTest.java
@@ -1,44 +1,33 @@
 package com.mobilejazz.cacheio.alternative.mappers.defaults;
 
+import com.mobilejazz.cacheio.alternative.mappers.KeyMapper;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class StringKeyMapperTest {
 
-    private final StringKeyMapper mapper = new StringKeyMapper();
+  private final KeyMapper<String> mapper = new StringKeyMapper();
 
-    @Test(expected = IllegalArgumentException.class)
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    public void testToStringWithNullInteger(){
-        mapper.toString(null);
-    }
+  @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void shouldThrowIllegalArgumentExceptionIfMappingToStringTheValueIsNull() {
+    mapper.toString(null);
+  }
 
-    @Test(expected = IllegalArgumentException.class)
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    public void testFromStringWithNullString(){
-        mapper.fromString(null);
-    }
+  @Test(expected = IllegalArgumentException.class) @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void shouldThrowIllegalArgumentExceptionIfMappingFromStringTheValueIsNull() {
+    mapper.fromString(null);
+  }
 
-    @Test
-    public void testMappingToString(){
+  @Test public void shouldMappingToStringAValue() throws Exception {
+    String result = mapper.toString("1");
 
-        assertThat(mapper.toString("1")).isEqualTo("1");
-        assertThat(mapper.toString("2")).isEqualTo("2");
-        assertThat(mapper.toString("3")).isEqualTo("3");
-        assertThat(mapper.toString("4")).isEqualTo("4");
+    assertThat(result).isEqualTo("1");
+  }
 
-        assertThat(mapper.toString("1")).isNotEqualTo("4");
-    }
+  @Test public void shouldMappingFromStringAValue() throws Exception {
+    String result = mapper.fromString("1");
 
-    @Test
-    public void testMappingFromString(){
-
-        assertThat(mapper.fromString("1")).isEqualTo("1");
-        assertThat(mapper.fromString("2")).isEqualTo("2");
-        assertThat(mapper.fromString("3")).isEqualTo("3");
-        assertThat(mapper.fromString("4")).isEqualTo("4");
-
-        assertThat(mapper.fromString("1")).isNotEqualTo(4L);
-    }
+    assertThat(result).isEqualTo("1");
+  }
 }


### PR DESCRIPTION
The default key mappers are:
- **DoubleKeyMapper**
- **FloatKeyMapper**
- **IntegerKeyMapper**
- **LongKeyMapper**
- **ShortKeyMapper**
- **StringKeyMapper**

I don't think that we need to add more default mappers. @aldoborrero @brianmcgee What do you think?

@brianmcgee  When you consider that everything is good please close the pull request.
